### PR TITLE
issue-010: Summary Screen Improvements (MVP-Plus)

### DIFF
--- a/ios/PracticeSessionView.swift
+++ b/ios/PracticeSessionView.swift
@@ -186,8 +186,25 @@ struct PracticeSessionView: View {
             Text("Session Complete!")
                 .font(.title)
 
+            // Block list with feedback
             if let session = engine.session {
-                Text("\(session.totalActualMinutes) minutes practiced")
+                VStack(spacing: 8) {
+                    ForEach(session.blocks) { block in
+                        HStack {
+                            Text(block.kind.displayName)
+                                .font(.subheadline)
+                            Text(":")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Text(block.feedback?.displayName ?? "—")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                        }
+                    }
+                }
+                .padding(.vertical, 8)
+
+                Text("Total: \(session.totalActualMinutes) min")
                     .font(.headline)
                     .foregroundColor(.secondary)
             }


### PR DESCRIPTION
## Summary

Enhances the session summary screen to match design.md Section 15 by adding a block list with feedback. The summary now shows all blocks that were completed with their feedback ratings, maintaining the minimal design philosophy.

## Changes

### Session Summary Enhancement

**Before:**
```
✓ Session Complete!

40 minutes practiced

[Done]
```

**After:**
```
✓ Session Complete!

Warm-Up : Good
Song : Hard
Solo : Good
Technique : Easy

Total: 40 min

[Done]
```

### Implementation Details

Updated `finishedView()` in `PracticeSessionView.swift`:
- Added block list between title and total minutes
- Each block displays: `Kind : Feedback`
- Format matches design.md Section 15 exactly
- Handles missing feedback with "—" placeholder
- Minimal text-only design (no colors, badges, or icons)

## Design.md Compliance

Per design.md Section 15 requirements:
- ✅ "Session complete" message
- ✅ List of blocks with feedback (newly added)
- ✅ Total session minutes
- ✅ Close button
- ✅ No charts or gamification
- ✅ Simple column layout

## Testing

Per issue #10 requirements:
- ✅ Visual verification via SwiftUI preview
- ✅ Completed session displays block list correctly
- ✅ Feedback values render properly
- ✅ No unit tests required (light testing only)

## Architecture Compliance

Per `claude.md`:
- ✅ No business logic added to view
- ✅ Data sourced from existing `engine.session`
- ✅ No new view models needed
- ✅ Purely presentational enhancement

## Files Changed

- `ios/PracticeSessionView.swift` - Enhanced `finishedView()` method

**Lines:** +18, -1

## Do NOT Items (per issue #10)

- ❌ No streaks or gamification added
- ❌ No SRS-specific details (stability, due dates)
- ❌ No changes to core flow
- ❌ No charts or analytics

---

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)