### PR TITLE
Streamline AI documentation: rename claude.md to architecture.md

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -36,7 +36,7 @@ Run this command to verify that your changes follow piq's architectural rules be
 
 For a thorough review, spawn a reviewer subagent or manually verify against:
 
-1. **`/docs/core/claude.md`** - Architecture, modules, platform constraints
+1. **`/docs/core/architecture.md`** - Architecture, modules, platform constraints
 2. **`/docs/core/design.md`** - UI/UX patterns, visual design system
 3. **`/docs/core/agents.md`** - Module boundaries and responsibilities
 4. **`/docs/core/tests.md`** - Testing priorities and TDD approach

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -24,7 +24,7 @@ When the user says "work on issue N" or you invoke `/issue N`:
 
 6. Create branch: `issue/N-<slug>` (if needed)
 7. Implement following all rules from `/docs/ai-instructions.md`:
-   - Architecture rules from `claude.md`
+   - Architecture rules from `architecture.md`
    - UI patterns from `design.md`
    - Module boundaries from `agents.md`
    - TDD approach from `tests.md`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@ This file contains all architecture rules, module boundaries, design patterns, w
 ## Quick Reference for Inline Suggestions
 
 ### Reading Order
-1. `docs/core/design.md` → `docs/core/claude.md` → `docs/core/agents.md` → `docs/core/tests.md`
+1. `docs/core/design.md` → `docs/core/architecture.md` → `docs/core/agents.md` → `docs/core/tests.md`
 2. Relevant `docs/guidance/` files
 3. Active `docs/issues/issue-*.md` if working on specific task
 

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -19,8 +19,8 @@ Read these files to understand the project architecture (order matters):
 1. **design.md** — UI/UX flows, visual design system, component patterns
    `/Users/stew/Repos/vibe/piq/docs/core/design.md`
 
-2. **claude.md** — Architecture, modules, platform constraints, patterns
-   `/Users/stew/Repos/vibe/piq/docs/core/claude.md`
+2. **architecture.md** — Architecture, modules, platform constraints, patterns
+   `/Users/stew/Repos/vibe/piq/docs/core/architecture.md`
 
 3. **agents.md** — Multi-agent collaboration patterns, responsibilities
    `/Users/stew/Repos/vibe/piq/docs/core/agents.md`
@@ -38,45 +38,36 @@ Read these files to understand the project architecture (order matters):
 
 ## Architecture Snapshot
 
-### Platform
-- **Target**: iOS 17+ only (iPhone-first, future watchOS)
-- **UI Framework**: SwiftUI (NavigationStack, TabView, .sheet/.fullScreenCover)
-- **State Management**: Observation (@Observable + .environment)
-- **Concurrency**: Swift Concurrency (async/await, Task{}, @MainActor for UI)
-- **App Entry**: PiqApp (@main) → RootView → TabView (Today, History, Settings)
+**Platform:** iOS 17+ only (SwiftUI + Observation + Swift Concurrency)
 
-### Core Modules
-Located in `ios/Modules/`:
+**App Entry:** PiqApp → RootView → TabView (Today, History, Settings)
 
-- **PracticeDomain**: Models (PracticeBlock, PracticeSession, PracticeBlockFeedback), engines (PracticeEngine, SpacedRepetitionEngine), persistence (PracticeStorage)
-- **SessionUI**: SwiftUI screens + small components (PracticeTimerView, MetronomeBar, FeedbackBar, SessionSummaryView)
-- **AudioHapticsModule**: MetronomeService, HapticService (timing & haptics only)
-- **HistoryModule**: ViewModels + views for past sessions
-- **SettingsModule**: User preferences UI
-- **ReferenceModule**: Skill catalog, reference diagrams
-- **WatchModule**: (future) watchOS companion
+**Core Modules** (located in `ios/Modules/`):
+- **PracticeDomain**: Models, engines (PracticeEngine, SpacedRepetitionEngine), persistence
+- **SessionUI**: Screens + small components (PracticeTimerView, MetronomeBar, FeedbackBar, etc.)
+- **AudioHapticsModule**: MetronomeService, HapticService
+- **HistoryModule / SettingsModule / ReferenceModule**: Thin ViewModels + views
 
-### Core Loop
+**Core Loop:**
 1. User opens app → sees **Today** tab with 4 blocks (Warm-Up, Song, Solo, Technique)
 2. Taps **Start session** → enters block-by-block timed practice
 3. After each block → answers **How was that? [Easy] [Good] [Hard]**
 4. At the end → sees simple session summary
 5. Over time, SpacedRepetitionEngine influences which items appear
 
-### State Machine
-`PracticeEngine.state` drives all UI:
+**State Machine:** `PracticeEngine.state` drives all UI
 - `.idle` → `.inBlock(index, remainingSeconds)` → `.betweenBlocks(lastIndex, nextIndex)` → `.finished`
 
 ---
 
-## Key Constraints
+## Key Constraints (STRICTLY ENFORCED)
 
-### Platform Rules (STRICTLY ENFORCED)
+### Platform Rules
 - ✅ SwiftUI only (NavigationStack, TabView, .sheet/.fullScreenCover)
 - ✅ Observation for state (no Combine, no @Published, no ObservableObject except bridging old APIs)
 - ✅ Swift Concurrency (async/await, not Combine)
 - ❌ **NO UIKit** (prohibited)
-- ❌ **NO Combine** (prohibited, use Swift Concurrency instead)
+- ❌ **NO Combine** (prohibited)
 - ❌ **NO timers in Views** (timers only in PracticeEngine and MetronomeService)
 - ❌ **NO business logic in Views** (Views observe state only, engines own logic)
 
@@ -86,24 +77,12 @@ Located in `ios/Modules/`:
 - **SpacedRepetitionEngine handles scheduling** — keeps SRE logic separate from session flow
 - **Views are thin and composable** — extract small components, no giant views
 - **Engines own logic/timers** — Views never create timers or contain business logic
-- **Store settings in UserDefaults**, history in SwiftData (simple JSON for now)
 
 ### Design Rules
-- **Minimal, calm, distraction-free** aesthetic — no clutter
-- **SF Symbols for all icons** — no custom icon assets unless essential
+- **Minimal, calm, distraction-free** aesthetic
+- **SF Symbols for all icons**
 - **System fonts** (rounded design where appropriate)
-- **Color**: .accent (blue) for primary actions, system colors for everything else
 - **12pt corner radius**, generous padding (16-24pt)
-- **Small composable views** — PracticeTimerView, MetronomeBar, FeedbackBar, etc.
-
-### Naming Conventions
-`referenceID` patterns (must match asset names):
-- Scale: `scale_<key>_<type>_pos<n>` (e.g., `scale_am_pentatonic_pos3`)
-- Chord: `chord_<root>_<quality>_<shape>` (e.g., `chord_g_major_open`)
-- Technique: `tech_<category>_<slug>` (e.g., `tech_bends_basic`)
-- Licks/Songs: `licks_blues_box1`, `song_<slug>_<section>`
-
-All lowercase, underscore-separated. Reuse exact asset name for lookup.
 
 ---
 
@@ -119,7 +98,7 @@ See `/docs/workflow/handle-issue.md` for detailed workflow.
 3. Create implementation plan (5-10 bullets)
 4. Ask ONE clarifying question if needed
 5. Get user confirmation before starting
-6. Implement following architecture rules from claude.md and agents.md
+6. Implement following architecture rules from architecture.md and agents.md
 7. Write/update tests (TDD for engines, see tests.md)
 8. Run `swift test` to verify
 9. Show `git diff`
@@ -143,28 +122,6 @@ Before committing changes, verify:
 - ✅ No business logic in Views (Views compose and observe engines)
 - ✅ Module boundaries respected (no cross-module coupling)
 - ✅ Tests exist for new engine logic (see tests.md priorities)
-- ✅ Naming conventions followed (referenceID patterns, asset names)
-
-### Implementation Patterns
-
-**Create session:**
-- Preferred: `engine.startSession(from: sre)` (with SpacedRepetitionEngine)
-- Demo: `engine.startSession()` (for manual testing)
-
-**Advance flow:**
-- `finishCurrentBlock()` → `recordFeedback(forBlockAt:feedback:)` → `startNextBlock()`
-
-**User actions:**
-- Pause/resume: `pause()` / `resume()`
-- Skip: `skipCurrentBlock()`
-- Extend: `extendCurrentBlock(byExtraSeconds:)`
-
-**Apply feedback to SRE:**
-- After finishing session: `sre.applyFeedback(for: session.blocks)` in `onSessionFinished` callback
-
-**Metronome:**
-- Toggle: `MetronomeService.start()` / `stop()`
-- BPM: `setBPM(_:)` or use +/- helpers
 
 ---
 
@@ -174,15 +131,14 @@ These patterns apply only when using Claude Code CLI. Other AI tools should foll
 
 ### Planner Subagent — For Feature Exploration
 **When to spawn:**
-- User requests new feature with unclear scope ("add warmup customization")
+- User requests new feature with unclear scope
 - Changes will affect multiple modules
 - Need to understand existing patterns before implementing
 
 **What it does:**
-- READ-ONLY codebase exploration (Glob, Grep, Read tools)
+- READ-ONLY codebase exploration
 - Pattern discovery and architecture analysis
 - Create implementation plan with critical files list
-- Identify architectural constraints and module boundaries
 
 ### Reviewer Subagent — Before Committing
 **When to spawn:**
@@ -191,7 +147,7 @@ These patterns apply only when using Claude Code CLI. Other AI tools should foll
 - Before creating PR
 
 **What it does:**
-- Check architectural compliance against claude.md and agents.md
+- Check architectural compliance against architecture.md and agents.md
 - Verify module boundaries not violated
 - Ensure no prohibited patterns (UIKit, Combine, timers in Views)
 - Verify test coverage for engine logic
@@ -205,7 +161,6 @@ These patterns apply only when using Claude Code CLI. Other AI tools should foll
 **What it does:**
 - Test development following tests.md TDD approach
 - Focus on engines first (PracticeEngine, SpacedRepetitionEngine)
-- Coverage gap identification
 - Swift test execution and reporting
 
 ---
@@ -229,99 +184,16 @@ These patterns apply only when using Claude Code CLI. Other AI tools should foll
 
 ---
 
-## Testing Focus (See tests.md for Details)
-
-### Priorities
-1. **Unit tests for PracticeEngine** — state transitions, timing, feedback recording
-2. **Unit tests for SpacedRepetitionEngine** — scheduling behavior, difficulty adjustments
-3. **Unit tests for PracticeStorage** — save/load sessions, handle edge cases
-4. **Light UI tests** — basic smoke tests only (Today renders 4 blocks, etc.)
-
-### TDD Recommendation
-- **Engines and storage**: Strongly favor TDD (write tests first or in parallel)
-- **UI**: Keep views small and composable, rely on manual testing + occasional snapshots
-- Focus TDD effort where logic is complex (timing, SRE)
-- Keep UI flexible and avoid heavy UI test investment
-
-### TDD Development Flow (6 Phases)
-See tests.md for detailed phase-by-phase flow:
-0. Domain skeleton (models + tests)
-1. PracticeEngine (TDD for state machine)
-2. SpacedRepetitionEngine (TDD for scheduling)
-3. Storage (TDD for persistence)
-4. Wire minimal UI (thin views, manual testing)
-5. Add components & refine UI (stateless presentational components)
-6. Iterate on SRE and history (always test-first for engine changes)
-
----
-
-## Do / Avoid
-
-### DO
-- Maintain module boundaries from agents.md
-- Keep engines pure and deterministic
-- Update docs (design.md, claude.md) when changing flows
-- Follow naming conventions (referenceID patterns)
-- Keep views declarative and stateless
-- Extract small composable components
-- Write tests for engine logic before refactoring
-- Surface ambiguities instead of guessing
-
-### AVOID
-- Adding timers in Views (only in engines)
-- Mixing SRE logic into PracticeEngine (keep separate)
-- Storing business logic in ViewModels (use engines)
-- Large view structs (extract components)
-- Ad-hoc persistence outside PracticeStorage
-- Introducing UIKit or Combine
-- Creating monoliths or god objects
-- Changing architecture without updating docs first
-
----
-
-## Extending the App
-
-Before adding new features:
-
-1. **Decide which module** it belongs to (see claude.md module descriptions)
-2. **Update design.md and claude.md** with conceptual changes first
-3. **Implement minimal changes** with tests following tests.md priorities
-4. **Keep daily session size small** (warmup first, fun ending last, interleaved middle)
-5. **Propose minimal diff** with clear rationale if uncertain
-
-### Common Extensions
-
-**Add new practice block type:**
-1. Add case to `PracticeBlockKind`
-2. Update mapping functions for labels/defaults
-3. Update session generation in PracticeEngine
-4. Update BlockListView to show new block
-5. Add tests for new flow
-
-**Add new reference diagram:**
-1. Create asset using naming conventions
-2. Add `PracticeReference` in PracticeReferenceService
-3. Attach `referenceID` to relevant blocks/items
-4. Confirm UI shows reference icon and opens sheet
-
-**Extend SRE behavior:**
-1. Modify SpacedRepetitionEngine only (keep isolated)
-2. Use PracticeBlockFeedback as input
-3. Do not move SRE logic into Views or PracticeEngine
-4. Add tests to validate new scheduling behavior
-
----
-
 ## Questions or Ambiguities
 
 If requirements are unclear or architecture decisions are needed:
 - **Surface them explicitly** instead of guessing
 - **Propose minimal diff** with clear rationale
-- **Reference specific docs** (design.md, claude.md, agents.md) to ground the discussion
+- **Reference specific docs** (design.md, architecture.md, agents.md) to ground the discussion
 - **Ask ONE focused question** to clarify before implementing
 
 ---
 
 **You are now ready to work on piq!**
 
-Follow the architecture rules strictly, maintain the calm minimal aesthetic, use TDD for engines, and keep Views thin and composable. When in doubt, read the detailed docs (claude.md, design.md, agents.md, tests.md) and ask clarifying questions.
+Follow the architecture rules strictly, maintain the calm minimal aesthetic, use TDD for engines, and keep Views thin and composable. When in doubt, read the detailed docs (architecture.md, design.md, agents.md, tests.md) and ask clarifying questions.

--- a/docs/core/agents.md
+++ b/docs/core/agents.md
@@ -6,13 +6,13 @@ monolithic changes, and respect design and platform rules.
 
 All agents must follow:
 - UX + flow rules in `design.md`
-- Architecture + platform rules in `claude.md`
+- Architecture + platform rules in `architecture.md`
 
 ---
 
 ## Platform Discipline
 
-All agents must respect the platform constraints in `claude.md`:
+All agents must respect the platform constraints in `architecture.md`:
 
 - SwiftUI‑only UI (`NavigationStack`, `TabView`, `.sheet`).  
 - Observation (`@Observable`, `.environment(...)`) for shared state.  
@@ -20,7 +20,7 @@ All agents must respect the platform constraints in `claude.md`:
 - No UIKit, storyboards, or Combine unless explicitly documented as an exception.
 
 If proposed code uses outdated patterns (e.g. `NavigationView`, `ObservableObject` for new types),
-it should be refactored to follow the platform section in `claude.md`.
+it should be refactored to follow the platform section in `architecture.md`.
 
 ---
 
@@ -29,7 +29,7 @@ it should be refactored to follow the platform section in `claude.md`.
 **Focus:** System design, module boundaries, avoiding monoliths.
 
 Responsibilities:
-- Owns and enforces the Module Map defined in `claude.md`.  
+- Owns and enforces the Module Map defined in `architecture.md`.  
 - Decides where new features belong (PracticeDomain, SessionUI, etc.).  
 - Ensures:
   - No god objects or giant view models.
@@ -54,7 +54,7 @@ Works mainly in:
 - `ReferenceModule`
 
 Responsibilities:
-- Build and refine SwiftUI screens using the component set from `claude.md`:
+- Build and refine SwiftUI screens using the component set from `architecture.md`:
   - `PracticeTimerView`
   - `MetronomeBar`
   - `FeedbackBar`
@@ -167,7 +167,7 @@ Responsibilities:
   - `PracticeStorage` saving/loading logic.
 - 
 - Coordinate with the Logic Agent to follow the "TDD Development Flow for the MVP"
-  defined in `claude.md`:
+  defined in `architecture.md`:
   - Start from models → PracticeEngine → SpacedRepetitionEngine → Storage.
   - Keep engines small, deterministic, and easy to test.
 Propose lightweight UI tests where valuable:
@@ -185,6 +185,6 @@ Must not:
 When starting a new task:
 
 1. Read `design.md` to understand flows, components, and visual rules.  
-2. Read `claude.md` for architecture, modules, and platform constraints.  
+2. Read `architecture.md` for architecture, modules, and platform constraints.  
 3. Skim existing Swift code in the affected module(s).  
 4. Then implement or refactor with minimal, focused changes.

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -1,4 +1,4 @@
-# claude.md — Implementation Guide for piq
+# architecture.md — Implementation Guide for piq
 
 This file tells AI assistants how to implement and extend **piq**, a minimal guitar practice companion app.
 It defines architecture, tech stack, modules, and patterns so changes stay consistent and non‑monolithic.
@@ -42,7 +42,7 @@ High‑level structure (suggested):
 ```text
 /docs
   /core
-    claude.md
+    architecture.md
     design.md
     agents.md
     tests.md
@@ -417,7 +417,7 @@ piq's documentation is organized into three layers:
 
 **1. `/docs/core/` — Stable reference docs**
 - `design.md` — UI/UX and flows
-- `claude.md` — architecture, modules, platform rules
+- `architecture.md` — architecture, modules, platform rules
 - `agents.md` — multi-agent roles and responsibilities
 - `tests.md` — testing philosophy and priorities
 
@@ -431,7 +431,7 @@ piq's documentation is organized into three layers:
 ### Required Reading Order for Any AI Agent Before Modifying Code
 
 1. `/docs/core/design.md`
-2. `/docs/core/claude.md`
+2. `/docs/core/architecture.md`
 3. `/docs/core/agents.md`
 4. `/docs/core/tests.md`
 5. Any relevant file in `/docs/guidance/` (e.g., `piq-guitar-guidance.md`)

--- a/docs/core/design.md
+++ b/docs/core/design.md
@@ -516,7 +516,7 @@ All screens must be built from small, composable components:
 - Extract new components when layout becomes complex or reused.  
 - Any new reusable visual pattern should be:
   - Documented here in `design.md`.  
-  - Promoted to a named SwiftUI component in `claude.md`.
+  - Promoted to a named SwiftUI component in `architecture.md`.
 
 Any change that affects user flows or layout should first update this design guide,
 then update the implementation.

--- a/docs/core/roadmap.md
+++ b/docs/core/roadmap.md
@@ -154,7 +154,7 @@ Actual implementation happens via:
 
 Every change must respect:
 - design.md (minimal UI)
-- claude.md (module boundaries)
+- architecture.md (module boundaries)
 - agents.md (roles)
 - tests.md (TDD)
 - piq-guitar-guidance.md (learning model)

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -171,7 +171,7 @@ Tests can live in `piqUITests` as a small suite, e.g. `PiqUITests.swift`.
 
 ## 7. TDD Development Flow (MVP)
 
-MVP sequence: Models → PracticeEngine (TDD) → SpacedRepetitionEngine (TDD) → PracticeStorage (TDD) → minimal UI → components → iterate. For engines/storage: write tests first. For UI: keep views thin, test engines instead. See claude.md Section 9 for detailed workflow.
+MVP sequence: Models → PracticeEngine (TDD) → SpacedRepetitionEngine (TDD) → PracticeStorage (TDD) → minimal UI → components → iterate. For engines/storage: write tests first. For UI: keep views thin, test engines instead. See architecture.md Section 9 for detailed workflow.
 
 ---
 

--- a/docs/docs-README.md
+++ b/docs/docs-README.md
@@ -9,7 +9,7 @@ The docs follow a strict 3-layer structure so that AI assistants can work consis
 # 1. Folder Structure
 /docs
 /core
-claude.md
+architecture.md
 design.md
 agents.md
 tests.md
@@ -30,7 +30,7 @@ issue-template.md
 These define PIQ’s unchanging rules:
 
 - **design.md** — UI/UX flows & visual rules  [oai_citation:5‡design.md](file-service://file-WbHhgc7refSDCwWbeHPJnu)  
-- **claude.md** — architecture, platform constraints, module boundaries  [oai_citation:6‡claude.md](file-service://file-3ExikRZvgDqHQnjTadmgG4)  
+- **architecture.md** — architecture, platform constraints, module boundaries  
 - **agents.md** — multi-agent roles & responsibilities  [oai_citation:7‡agents.md](file-service://file-Hv7q4zuHU6ddxkvCH7TKum)  
 - **tests.md** — TDD philosophy and testing priorities  [oai_citation:8‡tests.md](file-service://file-8eQfYHbiXyHf4c83DaLGGu)  
 
@@ -76,7 +76,7 @@ The provided **`issue-template.md`** ensures consistency.
 Before modifying code, any AI assistant must read these **in order**:
 
 1. `/docs/core/design.md`  
-2. `/docs/core/claude.md`  
+2. `/docs/core/architecture.md`  
 3. `/docs/core/agents.md`  
 4. `/docs/core/tests.md`  
 5. Relevant `/docs/guidance/` files (e.g., `piq-guitar-guidance.md`)  

--- a/docs/guidance/piq-guitar-guidance.md
+++ b/docs/guidance/piq-guitar-guidance.md
@@ -12,7 +12,7 @@ This file updates piq’s conceptual model to use a **research-backed guitar-lea
 It describes **what** piq should do at a high level and **how** to shape the codebase, so that a coding agent (e.g. Claude) can implement details while staying aligned with:
 
 - `design.md` — UI / UX / flows  
-- `claude.md` — architecture & modules  
+- `architecture.md` — architecture & modules  
 - `agents.md` — multi-agent roles  
 - `tests.md` — testing philosophy & TDD flow  
 
@@ -392,7 +392,7 @@ The details of the tests (file names, exact specs) belong in the test suite itse
 When an AI assistant (Claude, Copilot, etc.) works on piq and sees this file, it should:
 
 1. **Not** change the fundamental UX flows defined in `design.md`.  
-2. Respect architecture and module boundaries in `claude.md`.  
+2. Respect architecture and module boundaries in `architecture.md`.  
 3. Treat this file as the **conceptual spec** for:
    - Skill Catalog  
    - SRS behavior  

--- a/docs/workflow/handle-issue.md
+++ b/docs/workflow/handle-issue.md
@@ -5,7 +5,7 @@ When I say “work on issue #X”, follow this sequence:
 1. Fetch the GitHub Issue:
    gh issue view X --json number,title,body,labels
 
-2. Read the issue body + core docs (design.md, claude.md, agents.md, tests.md, piq-guitar-guidance.md).
+2. Read the issue body + core docs (design.md, architecture.md, agents.md, tests.md, piq-guitar-guidance.md).
 
 3. Summarize the plan in 5–10 bullets.
 

--- a/docs/workflow/load-context.md
+++ b/docs/workflow/load-context.md
@@ -4,7 +4,7 @@ Please initialize yourself for the **piq** iOS project.
 
 Re-read these files from disk using file_search (do NOT summarize them unless needed):
 - /mnt/data/design.md
-- /mnt/data/claude.md
+- /mnt/data/architecture.md
 - /mnt/data/agents.md
 - /mnt/data/tests.md
 - /mnt/data/piq-guitar-guidance.md


### PR DESCRIPTION
## Summary

Streamlines the AI documentation structure by eliminating redundancy and clarifying file purposes:

- Renamed `docs/core/claude.md` → `architecture.md` (more accurate name)
- Slimmed down `ai-instructions.md` from 328 to 199 lines (40% reduction)
- Removed all duplication between the two files
- Made `ai-instructions.md` a clean entry point that references detailed docs

## Changes

### File Rename
- `docs/core/claude.md` → `docs/core/architecture.md`

### Content Restructuring
**ai-instructions.md** (now 199 lines):
- Quick-start guide with reading order
- Architecture snapshot (high-level only)
- Key constraints summary
- Common workflows
- Platform-specific usage notes
- References detailed docs for implementation details

**architecture.md** (448 lines, unchanged content):
- Complete platform constraints
- Detailed module structure
- Full domain model documentation
- Component catalog
- Engine responsibilities
- TDD development flow
- All implementation patterns

### Reference Updates
Updated 13 files to reference `architecture.md` instead of `claude.md`:
- `.claude/commands/check.md`
- `.claude/commands/issue.md`
- `.github/copilot-instructions.md`
- `docs/core/agents.md` (7 references)
- `docs/core/design.md`
- `docs/core/roadmap.md`
- `docs/core/tests.md`
- `docs/docs-README.md` (3 references)
- `docs/guidance/piq-guitar-guidance.md` (2 references)
- `docs/workflow/handle-issue.md`
- `docs/workflow/load-context.md`

## New Documentation Hierarchy

**Entry Point:**
- `ai-instructions.md` - Slim reference that points to detailed docs

**Detailed Guides:**
- `docs/core/architecture.md` - Implementation guide (platform, modules, patterns)
- `docs/core/agents.md` - Multi-agent collaboration patterns
- `docs/core/design.md` - UI/UX flows and visual design
- `docs/core/tests.md` - Testing philosophy and TDD

## Benefits

1. **Clearer file names**: "architecture.md" is more descriptive than "claude.md"
2. **No duplication**: Each concept documented in exactly one place
3. **Better onboarding**: ai-instructions.md is now scannable and points to details
4. **Easier maintenance**: Changes to architecture only need updates in one file

## Test Plan

- [x] Verified all references updated (0 remaining "claude.md" references)
- [x] Confirmed ai-instructions.md reads as a clean entry point
- [x] Verified architecture.md maintains all original content
- [x] Checked reading order still makes sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)