### PR TITLE
Refactor documentation: separate roadmap (WHAT+WHEN) from guidance (WHY+HOW)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,9 +13,10 @@ architecture.md
 design.md
 agents.md
 tests.md
+roadmap.md
 
 /guidance
-piq-guitar-guidance.md
+guidance.md
 # Future: additional guidance files (e.g., scheduling, watchOS)
 
 /issues
@@ -43,7 +44,7 @@ These files explain **how major concepts work** and guide implementation across 
 
 Current files:
 
-- **piq-guitar-guidance.md** — research-backed guitar learning model, SRS, skill catalog, interleaving rules  [oai_citation:9‡piq-guitar-guidance.md](file-service://file-RTvy2MPPEfKctoRiZYuEKJ)  
+- **guidance.md** — research-backed guitar learning model, SRS, skill catalog, interleaving rules  
 
 Future additions may include:
 - scheduling-guidance.md  
@@ -75,11 +76,11 @@ The provided **`issue-template.md`** ensures consistency.
 
 Before modifying code, any AI assistant must read these **in order**:
 
-1. `/docs/core/design.md`  
-2. `/docs/core/architecture.md`  
-3. `/docs/core/agents.md`  
-4. `/docs/core/tests.md`  
-5. Relevant `/docs/guidance/` files (e.g., `piq-guitar-guidance.md`)  
+1. `/docs/core/design.md`
+2. `/docs/core/architecture.md`
+3. `/docs/core/agents.md`
+4. `/docs/core/tests.md`
+5. Relevant `/docs/guidance/` files (e.g., `guidance.md`)
 6. The specific `/docs/issues/issue-xxx.md` referenced in the user prompt  
 
 Only after these are read should the AI inspect or modify source code.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -28,11 +28,22 @@ Read these files to understand the project architecture (order matters):
 4. **tests.md** — Testing philosophy, TDD approach, priorities
    `/Users/stew/Repos/vibe/piq/docs/core/tests.md`
 
-5. **piq-guitar-guidance.md** — Guitar learning domain model, SRS concepts
-   `/Users/stew/Repos/vibe/piq/docs/guidance/piq-guitar-guidance.md`
+5. **guidance.md** — Guitar learning domain model, SRS concepts
+   `/Users/stew/Repos/vibe/piq/docs/guidance/guidance.md`
 
 6. **Active issue file** (if working on a specific task)
    `/Users/stew/Repos/vibe/piq/docs/issues/issue-*.md`
+
+## Optional Contextual Reading
+
+**roadmap.md** — Product phases and feature timeline
+   `/Users/stew/Repos/vibe/piq/docs/core/roadmap.md`
+
+Read this when:
+- Planning new features or creating issues
+- User asks about feature priorities or scope
+- Uncertain whether a feature belongs in MVP vs Phase 2+
+- Avoiding scope creep during implementation
 
 ---
 

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -422,7 +422,7 @@ piq's documentation is organized into three layers:
 - `tests.md` — testing philosophy and priorities
 
 **2. `/docs/guidance/` — High-level domain or feature guidance**
-- `piq-guitar-guidance.md` — research-backed guitar-learning model, skill catalog, and SRS concepts
+- `guidance.md` — research-backed guitar-learning model, skill catalog, and SRS concepts
 - Future domain or feature guidance files
 
 **3. `/docs/issues/` — Iteration-level tasks**
@@ -434,7 +434,7 @@ piq's documentation is organized into three layers:
 2. `/docs/core/architecture.md`
 3. `/docs/core/agents.md`
 4. `/docs/core/tests.md`
-5. Any relevant file in `/docs/guidance/` (e.g., `piq-guitar-guidance.md`)
+5. Any relevant file in `/docs/guidance/` (e.g., `guidance.md`)
 6. The specific `/docs/issues/issue-xxx-*.md` file referenced in the current prompt
 
 Agents must always read these files *before* inspecting or modifying source code.

--- a/docs/core/roadmap.md
+++ b/docs/core/roadmap.md
@@ -1,170 +1,127 @@
-# piq Roadmap (Evergreen, High-Level)
+# piq Product Roadmap
 
-This roadmap provides long-term direction for the **piq** iOS guitar practice app.  
-It aligns with the core documentation in `/docs/core/` and the conceptual model in `/docs/guidance/`.
+This roadmap defines **what** features to build and **when**.
 
-piq is a **practice coach**, not a lesson app.  
-It focuses on:
-- short, interleaved micro-sessions,
-- SRS-driven scheduling,
-- atomic skills,
-- minimal UX,
-- modular architecture.
-
-This roadmap avoids implementation details—those belong in `/docs/issues/`.
+For **why** and **how** to implement features, see `/docs/guidance/guidance.md`.
+For detailed architecture and patterns, see `/docs/core/` files.
 
 ---
 
-# 1. MVP (Core Experience)
+## Development Workflow
 
-## 1.1 Skill Catalog (Atomic Skills)
-- Seed catalog (~30–60 atomic practice items implemented)
-- Categories: warmup, fretboard, technique, theory, rhythm, chords, soloing, repertoire, songwork, ear_training, musicality (11 categories)
-- Reference diagrams (minimal)
-- See Section 1.7 for catalog structure details
+```
+roadmap.md (phases, features)
+    ↓
+GitHub Issues (specific tasks per phase)
+    ↓
+Implementation (following architecture + guidance docs)
+```
 
-## 1.2 Spaced Repetition Engine (SRE) v1
-- Stability-based scheduling (continuous values, starting at 1.0)
-- Easy/Good/Hard feedback → adaptive spacing
+This roadmap evolves slowly—only for major product direction changes.
+Day-to-day tasks and implementation details belong in GitHub Issues and `/docs/issues/`.
+
+---
+
+# Phase 1: MVP (Core Experience)
+
+**Goal:** Minimal viable practice coach that schedules skills and guides daily practice.
+
+## Features
+
+### Skill System
+- Predefined catalog of ~38 atomic practice items
+- 11 categories: warmup, fretboard, technique, theory, rhythm, chords, soloing, repertoire, songwork, ear_training, musicality
+- See `/docs/guidance/guidance.md` for detailed catalog structure
+
+### Spaced Repetition Engine (SRE)
+- Stability-based scheduling
+- Easy/Good/Hard feedback influences future scheduling
 - "Due today" item selection
 - Interleaving across categories
 
-## 1.3 Daily Session Generation
-- SRE → 6-8 PracticeBlocks → PracticeEngine
-- Each block is 2–15 minutes (configurable by category)
-- Session structure: warmup (first) + interleaved middle blocks + fun activity (last)
-- Target session duration: ~35 minutes (acceptable range: 25-45 min)
-- Category diversity enforced via interleaving algorithm
+### Daily Session Generation
+- 6-8 blocks per session
+- Block duration: 2-15 minutes (varies by category)
+- Session structure: warmup first → interleaved middle → fun ending
+- Target: ~30-40 minutes total (acceptable range: 25-45 min)
 
-## 1.4 Storage Integration
-- Persist PracticeItems + SRS state
-- Persist session history
-- Clean domain-storage boundaries
+### Storage & Persistence
+- Save/load PracticeItems with SRS state
+- Save/load session history
+- Separate catalog from user progress data
 
-## 1.5 Stable UI Flow
-- Today → Start → Block sequence → Feedback → Summary
-- Minimal text, clean visuals
-- Reference button (“?”)
+### UI Flow
+- Today screen → Start session → Block-by-block practice → Feedback → Summary
+- Minimal text, calm design
+- Reference diagrams ("?" button) for scales/chords/techniques
 
-MVP complete when user can:
-- open app,
-- start a session,
-- practice interleaved micro-skills across all categories (technique, fretboard, rhythm, repertoire, song, soloing, ear training, musicality),
-- give feedback,
-- get new sessions daily,
-- with persistence.
-
-## 1.7 Practice Block Catalog
-
-The app includes a predefined catalog of 38 practice items across 11 categories:
-
-**Catalog Structure:**
-- **Warmup** (2 items): Chromatic patterns, finger exercises
-- **Fretboard** (2 items): Note naming, octave shapes
-- **Technique** (4 items): Alternate picking, legato, bends, vibrato
-- **Theory** (2 items): Scale degrees, triad inversions
-- **Rhythm** (2 items): Strumming patterns, syncopation
-- **Chords** (6 items): Barre transitions, open switches, individual chord practice
-- **Soloing** (7 items): Am/Em pentatonic positions, blues licks
-- **Repertoire** (3 items): Song riffs and sections (Wonderwall, Nothing Else Matters, Hotel California)
-- **Songwork** (2 items): Full song practice (Blackbird, Stand By Me)
-- **Ear Training** (4 items): Major/minor key feel, hum and match root, straight vs swing, interval feel
-- **Musicality** (4 items): Dynamic control, controlled vibrato, bend accuracy, tone and touch
-
-**Storage & Persistence:**
-- Catalog items have stable `catalogID` strings for merging user SRS state with catalog updates
-- User progress (stability, nextDue) persists separately from catalog definitions
-- New items can be added to catalog without breaking user state
-
-**Extensibility:**
-- All items defined in `PracticeItemCatalog.swift`
-- Each item has optional `referenceID` linking to visual diagram assets
-- Custom items (user-created) planned for Phase 2+
-
-**File:** `/ios/Modules/PracticeDomain/PracticeItemCatalog.swift`
+**MVP Complete When:**
+User can open app, practice 6-8 interleaved micro-skills with timer and feedback, get new sessions daily, and all progress persists.
 
 ---
 
-# 2. Post-MVP (Phase 2+)
+# Phase 2: Enhanced Experience
 
-## 2.1 Enhanced History
+**Goal:** Richer feedback, customization, and history features.
+
+## Features
+
+### Enhanced History
 - Calendar view or session list
-- Trends (stability growth, streaks, categories practiced)
+- Trends: stability growth, categories practiced, streaks
 - Simple statistics (no scores or gamification)
 
-## 2.2 Custom Skill System
-- Users create custom PracticeItems (extension of existing catalog)
+### Custom Skill System
+- Users create custom PracticeItems
+- Integrates with SRE using same scheduling logic
 - Optional reference diagrams or short text
-- Integrates with SRE using same stability/scheduling logic
-- Custom items stored alongside catalog items with distinct catalogIDs
-- Custom items can be created in any category, including ear training and musicality
+- Stored alongside catalog items with distinct catalogIDs
 
-## 2.3 Improved Summary Screen
-- Clear feedback on:
-  - skills practiced,
-  - stability changes,
-  - next due dates,
-  - streaks
+### Improved Summary Screen
+- Show skills practiced, stability changes, next due dates
+- Streak tracking
 - Still minimal, no teaching content
 
-## 2.4 Better Reference Material
-- Slightly richer diagrams
+### Better Reference Material
+- Richer diagrams
 - Optional short hints (one sentence max)
 - No tutorials or lessons
-- References for ear training and musicality remain minimal (tiny cues, not theory lessons)
 
-## 2.5 Settings / Preferences
-- Adjust micro-session duration
-- Toggle metronome
-- Manage skill difficulty preferences
+### Enhanced Settings
+- Adjust block duration preferences
+- Metronome preferences
+- Category preferences
 
 ---
 
-# 3. Future Directions (Exploratory)
+# Phase 3: Future Explorations
 
-These are ideas, not commitments.
+**Status:** Ideas, not commitments. Evaluate after Phase 2 completion.
 
-## 3.1 watchOS Companion
-- Quick practice blocks
-- Morning micro-sessions
+### watchOS Companion
+- Quick practice blocks on wrist
 - Lightweight SRS reminders
 
-## 3.2 Widgets
-- Today’s due skills
+### Widgets
+- Home screen widget showing today's due skills
 - Quick-start session widget
 
-## 3.3 Import/Export
+### Import/Export
 - Backup SRS state
-- Share custom skills
+- Share custom skills between devices/users
 
-## 3.4 Audio & Haptics Enhancements
-- Better timing feedback
-- Optional tone/haptic metronome
-
----
-
-# 4. Workflow Alignment
-
-The roadmap defines direction.  
-Actual implementation happens via:
-
-- `/docs/issues/issue-xxx.md` (tasks)
-- `/docs/guidance/` (conceptual rules)
-- `/docs/core/` (architecture, UI, agents, testing)
-
-Every change must respect:
-- design.md (minimal UI)
-- architecture.md (module boundaries)
-- agents.md (roles)
-- tests.md (TDD)
-- piq-guitar-guidance.md (learning model)
+### Audio & Haptics Enhancements
+- Improved timing feedback
+- Optional haptic metronome patterns
 
 ---
 
-# 5. Evolution
+## Constraints (All Phases)
 
-This roadmap should evolve slowly.  
-Only major conceptual changes should update it.
-
-Day-to-day tasks belong in `/docs/issues/`.
+Every feature must respect:
+- **design.md** — minimal UI, calm aesthetic
+- **architecture.md** — module boundaries, platform constraints
+- **agents.md** — role separation
+- **tests.md** — TDD for engines
+- **guidance.md** — learning model and domain concepts
 

--- a/docs/guidance/guidance.md
+++ b/docs/guidance/guidance.md
@@ -1,22 +1,21 @@
-# piq — Research-Backed Guitar Learning Guidance (Skill Catalog + SRS + Flow)
+# piq — Learning Model & Implementation Guidance
 
-This file updates piq’s conceptual model to use a **research-backed guitar-learning architecture**, based on:
+This file defines **why** piq works the way it does and **how** to implement features correctly.
 
-- motor learning science  
-- contextual interference  
-- spaced repetition (facts + skills)  
-- micro-skill practice  
-- interleaving  
-- short guided sessions  
+## Purpose
 
-It describes **what** piq should do at a high level and **how** to shape the codebase, so that a coding agent (e.g. Claude) can implement details while staying aligned with:
+This is the conceptual foundation for piq's guitar learning model, based on:
+- Motor learning science
+- Contextual interference
+- Spaced repetition (procedural + declarative skills)
+- Micro-skill practice
+- Interleaving
+- Short guided sessions
 
-- `design.md` — UI / UX / flows  
-- `architecture.md` — architecture & modules  
-- `agents.md` — multi-agent roles  
-- `tests.md` — testing philosophy & TDD flow  
+For **what** features to build and **when**, see `/docs/core/roadmap.md`.
+For architecture and UI patterns, see `/docs/core/` files.
 
-This file is intentionally **conceptual + structural**. It does *not* prescribe every function signature; it gives Claude the “north star” for guitar learning inside piq.
+This file gives AI assistants the "north star" for implementing guitar learning features in piq.
 
 ---
 
@@ -137,57 +136,77 @@ This keeps `PracticeBlock` as “today’s schedule” and `PracticeItem` as “
 
 ---
 
-## 4. Skill Catalog (Conceptual)
+## 4. Skill Catalog
 
-piq should ship with a **small, opinionated Skill Catalog** that is:
+piq ships with a **small, opinionated Skill Catalog** that is:
+- Focused on beginner+ to intermediate players
+- Biased toward A minor pentatonic, basic open chords, core rock/pop/blues skills
+- Curated and finite, not open-ended
 
-- focused on **beginner+ to intermediate** players
-- biased toward A minor pentatonic, basic open chords, core rock/pop/blues skills
-- easily extended later
+### Catalog Structure (38 Items, 11 Categories)
 
-We don't need to encode the entire catalog in this file. Instead, define:
+**Warmup** (2 items):
+- Chromatic patterns
+- Finger exercises
 
-- There should be **30–60 seed `PracticeItem`s** at first launch.
-- They should cover:
+**Fretboard** (2 items):
+- Note naming
+- Octave shapes
 
-  - Technique:
-    - alternate picking (inside + outside string crossings)
-    - basic legato
-    - basic bends
-    - basic vibrato
+**Technique** (4 items):
+- Alternate picking (inside + outside string crossings)
+- Legato (hammer-ons, pull-offs)
+- Bends (basic control)
+- Vibrato (basic control)
 
-  - Fretboard:
-    - A minor pentatonic positions 1–5 (`scale_am_pentatonic_pos1` … `pos5`)
+**Theory** (2 items):
+- Scale degrees
+- Triad inversions
 
-  - Rhythm:
-    - simple 8th-note strumming pattern
-    - basic 16th-note feel
-    - simple shuffle feel
+**Rhythm** (2 items):
+- Strumming patterns (8th/16th notes)
+- Syncopation
 
-  - Repertoire:
-    - a few short blues/rock licks
-    - a simple riff or turnaround
+**Chords** (6 items):
+- Barre transitions
+- Open chord switches
+- Individual chord practice
 
-  - Song:
-    - 2–3 example song sections (e.g. "Wonderwall verse", "12-bar blues in E")
+**Soloing** (7 items):
+- Am/Em pentatonic positions 1-5
+- Blues licks
 
-  - Ear Training:
-    - major/minor key feel
-    - hum and match root note
-    - straight vs swing feel
-    - interval recognition
+**Repertoire** (3 items):
+- Song riffs and sections (Wonderwall, Nothing Else Matters, Hotel California)
 
-  - Musicality:
-    - dynamic control (quiet → loud)
-    - slow controlled vibrato
-    - bend accuracy
-    - tone and touch variation
+**Songwork** (2 items):
+- Full song practice (Blackbird, Stand By Me)
 
-The concrete items, IDs, and diagrams should be implemented in the codebase and asset catalog, but **this file's role** is to say:
+**Ear Training** (4 items):
+- Major/minor key feel
+- Hum and match root note
+- Straight vs swing feel
+- Interval recognition
+
+**Musicality** (4 items):
+- Dynamic control (quiet → loud)
+- Controlled vibrato
+- Bend accuracy
+- Tone and touch variation
+
+### Storage & Persistence
+
+- Catalog items have stable `catalogID` strings (e.g., `"tech_alt_picking"`)
+- User progress (`stability`, `nextDue`) persists separately from catalog definitions
+- New items can be added to catalog without breaking user state
+- Catalog stored in `/ios/Modules/PracticeDomain/PracticeItemCatalog.swift`
+- Each item has optional `referenceID` linking to visual diagram assets
+
+### Implementation Principle
 
 > piq should always have a curated, finite catalog of atomic skills, not an open-ended, unstructured list.
 
-Claude should treat the catalog as data, not logic.
+Treat the catalog as data, not logic. Custom items (user-created) will be added in Phase 2+.
 
 ---
 

--- a/docs/workflow/handle-issue.md
+++ b/docs/workflow/handle-issue.md
@@ -5,7 +5,7 @@ When I say “work on issue #X”, follow this sequence:
 1. Fetch the GitHub Issue:
    gh issue view X --json number,title,body,labels
 
-2. Read the issue body + core docs (design.md, architecture.md, agents.md, tests.md, piq-guitar-guidance.md).
+2. Read the issue body + core docs (design.md, architecture.md, agents.md, tests.md, guidance.md).
 
 3. Summarize the plan in 5–10 bullets.
 

--- a/docs/workflow/load-context.md
+++ b/docs/workflow/load-context.md
@@ -7,7 +7,7 @@ Re-read these files from disk using file_search (do NOT summarize them unless ne
 - /mnt/data/architecture.md
 - /mnt/data/agents.md
 - /mnt/data/tests.md
-- /mnt/data/piq-guitar-guidance.md
+- /mnt/data/guidance.md
 
 Also load the GitHub workflow file:
 - /mnt/data/handle-issue-lite.md (once added)


### PR DESCRIPTION
## Summary

This PR refactors the documentation structure to eliminate overlap between `roadmap.md` and the guidance files, establishing a clear workflow for phased development via GitHub Issues.

## Changes

### File Renames
- `docs/guidance/piq-guitar-guidance.md` → `docs/guidance/guidance.md`
- `docs/docs-README.md` → `docs/README.md`

### Refactored Files

**roadmap.md** - Now focuses on WHAT + WHEN
- Streamlined to product phases (Phase 1: MVP, Phase 2: Enhanced, Phase 3: Future)
- Removed detailed catalog structure (moved to guidance.md)
- Removed SRS implementation details (moved to guidance.md)
- Added clear workflow diagram
- Simplified to high-level features and goals only

**guidance.md** - Now focuses on WHY + HOW
- Contains detailed 38-item catalog structure
- Contains all SRS algorithm specifications
- Contains learning philosophy and research rationale
- Implementation guidance for AI assistants
- No phase/timeline language

### Updated References
All references to old filenames updated in:
- `docs/ai-instructions.md` (added roadmap.md as optional contextual reading)
- `docs/core/architecture.md`
- `docs/README.md`
- `docs/workflow/handle-issue.md`
- `docs/workflow/load-context.md`

## Development Workflow

```
roadmap.md (phases, features) 
    ↓
GitHub Issues (specific tasks per phase)
    ↓
Implementation (following both):
    - roadmap.md (what we're building)
    - guidance.md (how it should work)
    + core docs (architecture, design, agents, tests)
```

## Benefits

- **Clear separation:** Product planning vs. domain implementation
- **No overlap:** Each file has distinct purpose
- **Stable references:** Roadmap evolves slowly (product direction only)
- **Better workflow:** Easy to create focused GitHub Issues from roadmap phases
- **AI-friendly:** Clear guidance on when to read which files

🤖 Generated with [Claude Code](https://claude.com/claude-code)