### PR TITLE
Align docs with 6–8 microblock roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,5 @@
-# Repository Guidelines
+# AGENTS.md (Pointer)
 
-## Project Structure & Module Organization
-- iOS app lives in `ios/` with SwiftUI screens (`PracticeSessionView.swift`, `TodayView.swift`, `SettingsView.swift`, `RootView.swift`) and assets in `Assets.xcassets`.
-- Domain logic is in `ios/Modules/PracticeDomain` (engine/state, session generation, tempo learning) and companion modules for reference data (`ios/Modules/ReferenceModule`) and UI components (`ios/Modules/SessionUI`).
-- Tests sit in `ios/Tests`, split by domain (`PracticeDomainTests`), Today module, and reference module. Swift Package targets are defined in `Package.swift`.
-- Docs live under `docs/` for workflow, design, and issue templates.
-
-## Build, Test, and Development Commands
-- `open ios/Piq.xcodeproj` — launch the app workspace in Xcode.
-- `xcodebuild -scheme Piq -destination 'platform=iOS Simulator,name=iPhone 15' build` — headless build.
-- `swift test` — run package tests (PracticeDomain/Today/Reference) from the repo root.
-- `xed .` is fine for quick Xcode launches; simulators target iOS 17+.
-
-## Coding Style & Naming Conventions
-- Swift 5.9, SwiftUI-first. Prefer structs, value semantics, and @Observable/@Environment injection used in existing views.
-- Indent with 4 spaces (Xcode default). Keep view bodies small; extract subviews/helpers when branches grow.
-- Naming follows the module: `PracticeEngine`, `PracticeSessionView`, `MetronomeBar`. Use PascalCase for types, camelCase for vars/functions, and imperative names for actions (`handleMetronomeForBlock`).
-- Comments are minimal and purpose-driven; avoid repeating what the code already states.
-
-## Testing Guidelines
-- Framework: XCTest. Place new tests alongside their module in `ios/Tests/<Module>Tests`.
-- Name tests descriptively (`test...`) and cover engine state changes, timers, and UI logic where possible.
-- Run `swift test` (or Xcode test actions) before pushing; prefer fast domain tests for quick validation.
-
-## Commit & Pull Request Guidelines
-- Commits: concise, imperative/sentence-style summaries (e.g., “Refine session metronome control and time adjustments”).
-- PRs: link the relevant GitHub issue, summarize behavior changes, list test evidence (`swift test`, simulator runs), and include screenshots/GIFs for UI tweaks.
-- Branches generally follow `issue/<id>-short-description` (e.g., `issue/62-session-ui-tweaks`).
-
-## Security & Configuration Tips
-- No secrets are stored in the repo; keep API keys/config out of source. Use Xcode environment settings or local config files ignored by Git.
-- Audio/haptics rely on simulator/device permissions—verify on-device for anything timing-critical.
+Canonical roles and rules live in `docs/core/agents.md`.  
+Read that file (plus `design.md`, `architecture.md`, `tests.md`, `roadmap.md`) before changing code.  
+This pointer exists to prevent drift; keep the details in the core doc.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ These define PIQ’s unchanging rules:
 - **architecture.md** — architecture, platform constraints, module boundaries  
 - **agents.md** — multi-agent roles & responsibilities  [oai_citation:7‡agents.md](file-service://file-Hv7q4zuHU6ddxkvCH7TKum)  
 - **tests.md** — TDD philosophy and testing priorities  [oai_citation:8‡tests.md](file-service://file-8eQfYHbiXyHf4c83DaLGGu)  
+- **roadmap.md** — source-of-truth phases, scope, and priorities  
 
 These should change only when the overall system changes.
 
@@ -80,8 +81,9 @@ Before modifying code, any AI assistant must read these **in order**:
 2. `/docs/core/architecture.md`
 3. `/docs/core/agents.md`
 4. `/docs/core/tests.md`
-5. Relevant `/docs/guidance/` files (e.g., `guidance.md`)
-6. The specific `/docs/issues/issue-xxx.md` referenced in the user prompt  
+5. `/docs/core/roadmap.md`
+6. Relevant `/docs/guidance/` files (e.g., `guidance.md`)
+7. The specific `/docs/issues/issue-xxx.md` referenced in the user prompt  
 
 Only after these are read should the AI inspect or modify source code.
 

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -28,22 +28,14 @@ Read these files to understand the project architecture (order matters):
 4. **tests.md** — Testing philosophy, TDD approach, priorities
    `/Users/stew/Repos/vibe/piq/docs/core/tests.md`
 
-5. **guidance.md** — Guitar learning domain model, SRS concepts
-   `/Users/stew/Repos/vibe/piq/docs/guidance/guidance.md`
-
-6. **Active issue file** (if working on a specific task)
-   `/Users/stew/Repos/vibe/piq/docs/issues/issue-*.md`
-
-## Optional Contextual Reading
-
-**roadmap.md** — Product phases and feature timeline
+5. **roadmap.md** — Product phases, priorities, and source-of-truth scope
    `/Users/stew/Repos/vibe/piq/docs/core/roadmap.md`
 
-Read this when:
-- Planning new features or creating issues
-- User asks about feature priorities or scope
-- Uncertain whether a feature belongs in MVP vs Phase 2+
-- Avoiding scope creep during implementation
+6. **guidance.md** — Guitar learning domain model, SRS concepts
+   `/Users/stew/Repos/vibe/piq/docs/guidance/guidance.md`
+
+7. **Active issue file** (if working on a specific task)
+   `/Users/stew/Repos/vibe/piq/docs/issues/issue-*.md`
 
 ---
 
@@ -51,7 +43,7 @@ Read this when:
 
 **Platform:** iOS 17+ only (SwiftUI + Observation + Swift Concurrency)
 
-**App Entry:** PiqApp → RootView → TabView (Today, History, Settings)
+**App Entry:** PiqApp → RootView → NavigationStack + sidebar (Today, Profile, History, Settings)
 
 **Core Modules** (located in `ios/Modules/`):
 - **PracticeDomain**: Models, engines (PracticeEngine, SpacedRepetitionEngine), persistence
@@ -60,21 +52,21 @@ Read this when:
 - **HistoryModule / SettingsModule / ReferenceModule**: Thin ViewModels + views
 
 **Core Loop:**
-1. User opens app → sees **Today** tab with 4 blocks (Warm-Up, Song, Solo, Technique)
-2. Taps **Start session** → enters block-by-block timed practice
+1. User opens app → sees **Today** with 6–8 microblocks (Warm-Up first, interleaved middle, fun ending).
+2. Taps **Start session** → enters a 10s preview then block-by-block timed practice.
 3. After each block → answers **How was that? [Easy] [Good] [Hard]**
 4. At the end → sees simple session summary
-5. Over time, SpacedRepetitionEngine influences which items appear
+5. Over time, SpacedRepetitionEngine influences which items appear and suggests BPM for metronome-on blocks
 
 **State Machine:** `PracticeEngine.state` drives all UI
-- `.idle` → `.inBlock(index, remainingSeconds)` → `.betweenBlocks(lastIndex, nextIndex)` → `.finished`
+- `.idle` → `.previewBlock(index, secondsRemaining)` → `.inBlock(index, remainingSeconds)` → `.betweenBlocks(lastIndex, nextIndex)` → `.finished`
 
 ---
 
 ## Key Constraints (STRICTLY ENFORCED)
 
 ### Platform Rules
-- ✅ SwiftUI only (NavigationStack, TabView, .sheet/.fullScreenCover)
+- ✅ SwiftUI only (NavigationStack, sidebar overlay, .sheet/.fullScreenCover)
 - ✅ Observation for state (no Combine, no @Published, no ObservableObject except bridging old APIs)
 - ✅ Swift Concurrency (async/await, not Combine)
 - ❌ **NO UIKit** (prohibited)

--- a/docs/core/agents.md
+++ b/docs/core/agents.md
@@ -171,7 +171,7 @@ Responsibilities:
   - Start from models → PracticeEngine → SpacedRepetitionEngine → Storage.
   - Keep engines small, deterministic, and easy to test.
 Propose lightweight UI tests where valuable:
-  - Today screen renders 4 blocks.  
+  - Today screen renders generated microblocks (6–8).  
   - Practice screen navigates through block → feedback → next block.
 - Encourage a light TDD style for core logic (engines) where feasible.
 

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -9,7 +9,7 @@ It defines architecture, tech stack, modules, and patterns so changes stay consi
 
 **App name:** piq  
 **Platform:** iOS (iPhone‑first), future watchOS companion  
-**Concept:** A calm, minimal app that tells the user what to practice today, in 4 guided blocks, with timers,
+**Concept:** A calm, minimal app that tells the user what to practice today, in 6–8 guided microblocks, with timers,
 simple feedback (Easy/Good/Hard), and light references (diagrams + optional external lessons).
 
 piq is a **practice coach**, not a teaching platform. It schedules and guides practice; it does not contain
@@ -17,8 +17,8 @@ full lessons or long written explanations.
 
 ### Core Loop
 
-1. User opens app → sees the **Today** screen with 4 blocks (Warm‑Up, Song, Solo, Technique).  
-2. Taps **Start session** → enters block‑by‑block timed practice.  
+1. User opens app → sees the **Today** screen with 6–8 microblocks (Warm‑Up first, interleaved middle, fun ending).  
+2. Taps **Start session** → enters a 10s preview then block‑by‑block timed practice.  
 3. After each block → answers **How was that? [Easy] [Good] [Hard]**.  
 4. At the end → sees a simple session summary.  
 5. Over time, a spaced‑repetition engine (SRE) will influence which items appear.
@@ -177,7 +177,7 @@ Displays "How was that?" with three buttons: [Easy] [Good] [Hard]. Accepts three
 
 ### BlockListView
 
-Displays today's 4 blocks on Today screen. Accepts blocks array, start session callback.
+Displays today's 6–8 microblocks on Today screen. Accepts blocks array, start session callback.
 
 ### SongChoiceSheet
 
@@ -199,6 +199,7 @@ Engines own logic; Views and ViewModels compose them.
 - Owns current block index and timing state.  
 - Exposes a simple state machine, e.g.:
   - `.idle`
+  - `.previewBlock(index: Int, secondsRemaining: Int)`
   - `.inBlock(index: Int, remainingSeconds: Int)`
   - `.betweenBlocks(lastIndex: Int, nextIndex: Int?)`
   - `.finished`
@@ -219,7 +220,7 @@ PracticeEngine does **not**:
   - Next due times
   - Difficulty/ease factors
 - Consumes feedback signals (Easy/Good/Hard) on blocks/items.
-- Produces “today’s list” of recommended items for session generation.
+- Produces “today’s list” of recommended items for session generation (6–8 microblocks; warmup first, interleaved middle, fun ending; suggested BPM for metronome-on blocks).
 
 SpacedRepetitionEngine does **not**:
 - Own UI or timers.
@@ -242,9 +243,9 @@ MetronomeService does **not**:
 - Handles persistence for:
   - Completed `PracticeSession`s.
   - Light user preferences (level, styles, cues).  
-  - SRE state (due dates, etc.) if needed.
-- Start simple (UserDefaults / JSON file).  
-  SwiftData / CoreData can be added later.
+  - SRE/tempo state (due dates, BPM history).
+- Merges seed catalog with stored SRS/tempo on load; saves updated sessions/items after each session via `PracticeEngine.onSessionFinished`.
+- Start simple (UserDefaults / JSON file). SwiftData / CoreData can be added later.
 
 ---
 
@@ -322,7 +323,7 @@ Testing should focus on **core logic first**, then light UI tests.
    - Handle empty / first‑run cases gracefully.
 
 4. **Light UI tests / snapshots (optional)**
-   - Basic smoke tests that Today screen renders 4 blocks.  
+   - Basic smoke tests that Today screen renders generated microblocks (6–8).  
    - Practice screen shows timer and buttons.  
    - Feedback screen shows 3 choices.
 
@@ -346,7 +347,7 @@ Use this rough sequence when building out the first version of piq:
    - Define core models: `PracticeBlockKind`, `PracticeBlock`, `PracticeSession`, `PracticeBlockFeedback`.
    - Add simple factory helpers (e.g. `PracticeSession.makeTodayDemo()`).
    - Tests:
-     - Model invariants (e.g. 4 blocks per session, kinds in expected order).
+     - Model invariants (e.g. warmup-first ordering, fun ending last, total microblocks within 6–8).
      - Basic derived properties (e.g. total minutes).
 
 2. **Phase 1 – PracticeEngine (driven by tests)**
@@ -365,7 +366,7 @@ Use this rough sequence when building out the first version of piq:
      - Items marked Easy appear less frequently.
      - Items marked Hard appear more frequently.
    - Implement minimal `SpacedRepetitionEngine` that passes these tests.
-   - Wire a basic `generateTodaySession()` that returns 4 blocks.
+   - Wire a basic `generateTodaySession()` that returns 6–8 microblocks (warmup first, interleaved middle, fun ending).
 
 4. **Phase 3 – Storage**
    - Write tests for `PracticeStorage`:
@@ -377,7 +378,7 @@ Use this rough sequence when building out the first version of piq:
    - Create `RootView`, `TodayView`, and a very simple `PracticeSessionView`.
    - Do NOT write exhaustive UI tests at this stage.
    - Confirm manually in simulator that:
-     - Today shows 4 blocks from engine.
+     - Today shows generated microblocks from engine.
      - Starting a session moves engine to `.inBlock`.
      - Timer updates the view via observation.
 

--- a/docs/core/design.md
+++ b/docs/core/design.md
@@ -81,19 +81,14 @@ Icons should be:
 Every practice session follows this sequence:
 
 ```text
-Today → Start session → Block screen → Feedback → Next block → … → Session summary
+Today → Start session → Preview (10s) → Block screen → Feedback → Next block → … → Session summary
 ```
 
-Blocks:
-- Warm‑Up  
-- Song  
-- Solo  
-- Technique  
-
-User sees:
-- Exactly 4 blocks per session.  
-- Each block ~10 minutes (configurable).  
-- After each block, a short feedback step: Easy / Good / Hard.
+Session structure:
+- 6–8 microblocks per session (≈25–45 min total).  
+- Warm‑Up first, interleaved middle, “fun ending” block last.  
+- Each microblock 2–10 minutes depending on category.  
+- Feedback after every block: Easy / Good / Hard.
 
 ---
 
@@ -309,7 +304,7 @@ On first launch, the user goes through a short, minimal onboarding:
    - Primary button: `[Done]`
 
 5. **First Session Summary**
-   - Shows 4 blocks for today (Warm‑Up, Song, Solo, Technique).  
+   - Planned: shows today’s 6–8 microblocks (Warm‑Up first, interleaved middle, fun ending).  
    - Primary button: `[Start session]`
 
 No tutorials, no long explanations.
@@ -318,7 +313,9 @@ No tutorials, no long explanations.
 
 # 9. Practice Blocks
 
-The 4 block types:
+Session mix: 6–8 microblocks per day (≈25–45 min), always starting with Warm‑Up and ending with a “fun” block. Middle blocks interleave categories to avoid repeats.
+
+The core block types:
 
 - **Warm‑Up**  
   - Scales, patterns, mechanics.  
@@ -384,6 +381,7 @@ UI rules:
 - Use `metronome` SF Symbol only.  
 - Do not show the word "Metronome".  
 - Show numeric BPM and +/- icons only.
+- Record starting/ending BPM and +/- taps for metronome-on blocks to feed tempo learning.
 
 ---
 
@@ -413,17 +411,23 @@ The Practice screen uses these components:
   - Renders concentric rings and central timer content.
 - `MetronomeBar`  
   - Renders the icon‑based metronome row.
+- Preview state  
+  - 10s countdown before each block; tap anywhere to start immediately.
 - Bottom control row  
   - Three buttons: Skip, +2:00, Finish.
+- Instruction card  
+  - Tap to open sheet with full bullets and diagram if available.
 
 Layout:
 
 ```text
 VStack
   HStack: [Block kind label]   [questionmark.circle?]
+  (Preview: 10s countdown, tap to start)
   PracticeTimerView
   MetronomeBar
   HStack: [Skip] [+2:00] [Finish]
+  Instruction card (tappable)
 ```
 
 ## Feedback Screen Composition
@@ -448,9 +452,11 @@ Layout:
 Session complete
 
 Warm‑Up: Good
+Fretboard: Good
 Song: Hard
 Solo: Good
 Technique: Easy
+Fun ending: Good
 
 Total: 38 min
 

--- a/docs/core/roadmap.md
+++ b/docs/core/roadmap.md
@@ -1,127 +1,72 @@
-# piq Product Roadmap
+# piq Product Roadmap (Source of Truth)
 
-This roadmap defines **what** features to build and **when**.
-
-For **why** and **how** to implement features, see `/docs/guidance/guidance.md`.
-For detailed architecture and patterns, see `/docs/core/` files.
+Last updated: 2025-11-29  
+Scope: what to build and when. Why/how live in `/docs/guidance/guidance.md` and `/docs/core/`.
 
 ---
 
 ## Development Workflow
+roadmap.md → GitHub issues (/docs/issues/* or GitHub) → implementation
 
-```
-roadmap.md (phases, features)
-    ↓
-GitHub Issues (specific tasks per phase)
-    ↓
-Implementation (following architecture + guidance docs)
-```
-
-This roadmap evolves slowly—only for major product direction changes.
-Day-to-day tasks and implementation details belong in GitHub Issues and `/docs/issues/`.
+Roadmap changes are rare and intentional. Iteration detail belongs in issues.
 
 ---
 
-# Phase 1: MVP (Core Experience)
-
-**Goal:** Minimal viable practice coach that schedules skills and guides daily practice.
-
-## Features
-
-### Skill System
-- Predefined catalog of ~38 atomic practice items
-- 11 categories: warmup, fretboard, technique, theory, rhythm, chords, soloing, repertoire, songwork, ear_training, musicality
-- See `/docs/guidance/guidance.md` for detailed catalog structure
-
-### Spaced Repetition Engine (SRE)
-- Stability-based scheduling
-- Easy/Good/Hard feedback influences future scheduling
-- "Due today" item selection
-- Interleaving across categories
-
-### Daily Session Generation
-- 6-8 blocks per session
-- Block duration: 2-15 minutes (varies by category)
-- Session structure: warmup first → interleaved middle → fun ending
-- Target: ~30-40 minutes total (acceptable range: 25-45 min)
-
-### Storage & Persistence
-- Save/load PracticeItems with SRS state
-- Save/load session history
-- Separate catalog from user progress data
-
-### UI Flow
-- Today screen → Start session → Block-by-block practice → Feedback → Summary
-- Minimal text, calm design
-- Reference diagrams ("?" button) for scales/chords/techniques
-
-**MVP Complete When:**
-User can open app, practice 6-8 interleaved micro-skills with timer and feedback, get new sessions daily, and all progress persists.
+## Status Legend
+- **Shipped**: in code now
+- **Next**: MVP-completion focus
+- **Future**: queued after MVP
+- **Explorations**: evaluate later
 
 ---
 
-# Phase 2: Enhanced Experience
-
-**Goal:** Richer feedback, customization, and history features.
-
-## Features
-
-### Enhanced History
-- Calendar view or session list
-- Trends: stability growth, categories practiced, streaks
-- Simple statistics (no scores or gamification)
-
-### Custom Skill System
-- Users create custom PracticeItems
-- Integrates with SRE using same scheduling logic
-- Optional reference diagrams or short text
-- Stored alongside catalog items with distinct catalogIDs
-
-### Improved Summary Screen
-- Show skills practiced, stability changes, next due dates
-- Streak tracking
-- Still minimal, no teaching content
-
-### Better Reference Material
-- Richer diagrams
-- Optional short hints (one sentence max)
-- No tutorials or lessons
-
-### Enhanced Settings
-- Adjust block duration preferences
-- Metronome preferences
-- Category preferences
+## Foundations (Shipped)
+- Seed catalog (~38 items) across 11 categories with instructions/focus cues and references.
+- Spaced Repetition Engine: stability-based ordering, due/priority queries, feedback application, tempo learning.
+- Session generation: 6–8 microblocks (~25–45 min) with warmup first, interleaved middle, fun ending; suggested BPM for metronome-on blocks.
+- PracticeEngine: preview → inBlock → betweenBlocks → finished; pause/extend/adjust/skip; feedback capture; timer ownership.
+- Tempo & feedback loop: MetronomeService + HapticService, starting/ending BPM capture, tempo adjustment tracking.
+- Persistence v2: sessions + SRS/tempo state saved/loaded; merge seed catalog with stored state; history stats/trends.
+- UI flows: sidebar RootView; Today (reorder/remove, resume active session); Practice session with preview + instructions card + metronome; Feedback step; History list/stats; Settings (BPM, haptics, reset/clear data).
 
 ---
 
-# Phase 3: Future Explorations
+## Phase 1 – MVP Completion (Next)
+Goal: ship a coherent daily practice coach with reliable 6–8 microblocks and onboarding.
 
-**Status:** Ideas, not commitments. Evaluate after Phase 2 completion.
+- Confirm and document the 6–8 microblock structure (durations per category) across design/architecture/guidance/UI copy.
+- Onboarding (planned): level, styles, cues → seed preferences and initial catalog emphasis.
+- Session polish: summary screen clarity (feedback + minutes), safer state handling/resume, align Today/Practice UI to microblock structure.
+- Reliability: tighten PracticeEngine/SRE/storage tests; handle empty/edge cases; ensure persistence schema v2 is stable.
+- References: ensure question-mark affordance and sheets cover existing catalog.
 
-### watchOS Companion
-- Quick practice blocks on wrist
-- Lightweight SRS reminders
+**Done when:** user can onboard, get 6–8 guided microblocks daily, complete with metronome/haptics, give feedback, see history saved, and state resumes safely.
 
-### Widgets
-- Home screen widget showing today's due skills
-- Quick-start session widget
+---
 
-### Import/Export
-- Backup SRS state
-- Share custom skills between devices/users
+## Phase 2 – Enhanced Experience (Future)
+Goal: customization and insight.
 
-### Audio & Haptics Enhancements
-- Improved timing feedback
-- Optional haptic metronome patterns
+- Custom practice items (user-created) using same SRE/tempo pipelines.
+- History depth: calendar/list hybrid, streaks/trends, per-category stats.
+- Settings depth: block duration preferences, metronome defaults, category preferences.
+- Reference richness: more diagrams + succinct hints; optional external links.
+- Summary improvements: stability/next-due hints; minimal streak view; still no teaching text.
+
+---
+
+## Phase 3 – Explorations (Evaluate after Phase 2)
+- watchOS companion for quick blocks and reminders.
+- Widgets (today’s due skills, quick start).
+- Import/export for SRS/tempo state and custom items.
+- Audio/haptics refinements (patterns, improved timing).
+- Any AI coach/backing-track/gamification ideas remain exploratory until core experience is solid.
 
 ---
 
 ## Constraints (All Phases)
-
-Every feature must respect:
-- **design.md** — minimal UI, calm aesthetic
-- **architecture.md** — module boundaries, platform constraints
-- **agents.md** — role separation
-- **tests.md** — TDD for engines
-- **guidance.md** — learning model and domain concepts
-
+- **design.md** — minimal, calm UI; SF Symbols; no teaching walls of text.
+- **architecture.md** — SwiftUI + Observation; engines own logic/timers; module boundaries.
+- **agents.md** — role separation and ownership.
+- **tests.md** — engines/storage first; TDD-leaning for logic.
+- **guidance.md** — learning model, skill catalog, interleaving/SRS rules.

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -45,7 +45,7 @@ Priority order:
 Examples of behaviors to test:
 
 - A `PracticeSession` created for "today" has:
-  - 4 blocks in the expected order (Warm-Up, Song, Solo, Technique).
+  - 6–8 microblocks with Warm-Up first, interleaved middle, and a fun ending last.
 - `totalMinutes` is computed correctly from block minutes.
 - `PracticeBlockFeedback` values roundtrip correctly (e.g., save/load, mapping).
 
@@ -149,7 +149,7 @@ UI tests are **smoke tests**, not spec tests.
 ### 6.1 Today → Session Flow
 
 - Start app → Today tab is visible by default.
-- Today tab shows 4 blocks (kinds visible somewhere).
+- Today tab shows generated microblocks (6–8, kinds visible somewhere).
 - Tapping `[Start session]` presents the practice screen.
 
 ### 6.2 Block → Feedback → Next Block
@@ -162,7 +162,7 @@ UI tests are **smoke tests**, not spec tests.
 ### 6.3 End of Session
 
 - After the last block’s feedback:
-  - A Session summary appears with all 4 blocks and feedback summary.
+  - A Session summary appears with all practiced blocks and feedback summary.
   - `[Close]` returns to Today or History as designed.
 
 Tests can live in `piqUITests` as a small suite, e.g. `PiqUITests.swift`.

--- a/docs/guidance/guidance.md
+++ b/docs/guidance/guidance.md
@@ -50,7 +50,7 @@ All domain and implementation details should support this.
 ### 2.1 Micro-Sessions
 
 - Each **PracticeBlock** is a *micro-session*: ~2–5 minutes, not 20+.  
-- A daily session is 3–6 micro-sessions, grouped into ~4 blocks for now.  
+- A daily session is 6–8 micro-sessions (≈25–45 minutes total): warmup first, interleaved middle, “fun ending” last.  
 - Micro-sessions focus on *one* atomic skill at a time.
 
 ### 2.2 Interleaving


### PR DESCRIPTION
## Summary
- make docs/core/roadmap.md the canonical source for 6–8 microblock sessions with status tags
- align design/guidance/architecture/ai-instructions/tests/agents/README to microblock structure, preview state, tempo learning, sidebar entry
- reduce root AGENTS.md to a pointer to avoid drift

## Testing
- not run (docs-only)