### PR TITLE
Add reliability coverage for practice engine, SRE, and storage v2

### DIFF
--- a/ios/Modules/PracticeDomain/PracticeStorage.swift
+++ b/ios/Modules/PracticeDomain/PracticeStorage.swift
@@ -159,7 +159,8 @@ final class PracticeStorage {
     /// Load all sessions from storage with automatic migration.
     ///
     /// Handles multiple schema versions:
-    /// - v1 (current): SessionsStore wrapper with schemaVersion
+    /// - v2 (current): SessionsStore wrapper with schemaVersion + tempo fields
+    /// - v1: SessionsStore wrapper without tempo fields
     /// - v0 (legacy): Unwrapped array format
     ///
     /// Returns empty array on any load failure (corrupted data, unknown version, etc.)
@@ -182,13 +183,13 @@ final class PracticeStorage {
 
     /// Internal method to load and migrate sessions data.
     private func loadSessionsWithMigration(from data: Data) throws -> [PracticeSession] {
-        // Try to decode as current version (v1)
+        // Try to decode as current version (v2)
         if let store = try? decoder.decode(SessionsStore.self, from: data) {
             // Check if this is a known version
             if store.schemaVersion > Self.schemaVersion {
                 throw LoadError.unknownSchemaVersion(store.schemaVersion)
             }
-            // Currently only v1 exists, return as-is
+            // Current version is v2; v1 remains compatible with new fields defaulted
             // Future: Add migration logic here for older versions
             return store.sessions
         }
@@ -227,7 +228,8 @@ final class PracticeStorage {
     /// Load all items from storage with automatic migration.
     ///
     /// Handles multiple schema versions:
-    /// - v1 (current): ItemsStore wrapper with schemaVersion
+    /// - v2 (current): ItemsStore wrapper with schemaVersion + tempo state
+    /// - v1: ItemsStore wrapper without tempo state
     /// - v0 (legacy): Unwrapped array format
     ///
     /// Returns empty array on any load failure (corrupted data, unknown version, etc.)
@@ -250,13 +252,13 @@ final class PracticeStorage {
 
     /// Internal method to load and migrate items data.
     private func loadItemsWithMigration(from data: Data) throws -> [PracticeItem] {
-        // Try to decode as current version (v1)
+        // Try to decode as current version (v2)
         if let store = try? decoder.decode(ItemsStore.self, from: data) {
             // Check if this is a known version
             if store.schemaVersion > Self.schemaVersion {
                 throw LoadError.unknownSchemaVersion(store.schemaVersion)
             }
-            // Currently only v1 exists, return as-is
+            // Current version is v2; v1 remains compatible with new tempo defaults
             // Future: Add migration logic here for older versions
             return store.items
         }

--- a/ios/Tests/PracticeDomainTests/PracticeEngineTests.swift
+++ b/ios/Tests/PracticeDomainTests/PracticeEngineTests.swift
@@ -59,6 +59,19 @@ final class PracticeEngineTests: XCTestCase {
         }
     }
 
+    func testStartSessionWithEmptyBlocksDoesNothing() {
+        let engine = PracticeEngine()
+        engine.startSession(with: [])
+
+        if case .idle = engine.state {
+            // Success
+        } else {
+            XCTFail("Engine should remain idle when starting with empty blocks")
+        }
+
+        XCTAssertNil(engine.session)
+    }
+
     // MARK: - Tick/Advance Tests
 
     func testTickDecrementsRemainingSeconds() {
@@ -223,6 +236,21 @@ final class PracticeEngineTests: XCTestCase {
             XCTAssert(remainingSeconds >= 180, "Second block should have reasonable duration")
         } else {
             XCTFail("Engine should be in block state")
+        }
+    }
+
+    func testStartNextBlockNoOpWhenNotBetweenBlocks() {
+        let engine = PracticeEngine()
+        engine.startSession()
+
+        // Calling startNextBlock from preview should keep the same preview state
+        engine.startNextBlock()
+
+        if case .previewBlock(let index, let secondsRemaining) = engine.state {
+            XCTAssertEqual(index, 0)
+            XCTAssertEqual(secondsRemaining, 10)
+        } else {
+            XCTFail("Engine should remain in preview when startNextBlock is called outside betweenBlocks")
         }
     }
 
@@ -444,6 +472,22 @@ final class PracticeEngineTests: XCTestCase {
         }
     }
 
+    func testPausePreventsPreviewCountdown() {
+        let engine = PracticeEngine()
+        let block = PracticeBlock(kind: .warmup, title: "Custom Warmup", targetMinutes: 1, instructions: [])
+        engine.startSession(with: [block])
+
+        engine.pause()
+        engine.tick()
+
+        if case .previewBlock(let index, let secondsRemaining) = engine.state {
+            XCTAssertEqual(index, 0)
+            XCTAssertEqual(secondsRemaining, 10)
+        } else {
+            XCTFail("Engine should remain in preview when paused")
+        }
+    }
+
     // MARK: - Current Block Info Tests
 
     func testCurrentBlockIndexReturnsCorrectValue() {
@@ -478,6 +522,41 @@ final class PracticeEngineTests: XCTestCase {
     }
 
     // MARK: - Full Session Flow Tests
+
+    func testSingleBlockFlowFromPreviewToFinished() {
+        let engine = PracticeEngine()
+        let block = PracticeBlock(kind: .warmup, title: "One Minute", targetMinutes: 1, instructions: [])
+        engine.startSession(with: [block])
+
+        // Countdown through preview to enter inBlock
+        for _ in 0..<10 { engine.tick() }
+
+        if case .inBlock(let index, let remainingSeconds) = engine.state {
+            XCTAssertEqual(index, 0)
+            XCTAssertEqual(remainingSeconds, 60)
+        } else {
+            XCTFail("Engine should enter inBlock after preview ticks")
+        }
+
+        // Finish via tick transition to betweenBlocks then finished
+        engine.state = .inBlock(index: 0, remainingSeconds: 1)
+        engine.tick()
+
+        if case .betweenBlocks(let lastIndex, let nextIndex) = engine.state {
+            XCTAssertEqual(lastIndex, 0)
+            XCTAssertNil(nextIndex)
+        } else {
+            XCTFail("Engine should move to betweenBlocks after final tick")
+        }
+
+        engine.startNextBlock()
+
+        if case .finished = engine.state {
+            // Success
+        } else {
+            XCTFail("Engine should finish after final block completes")
+        }
+    }
 
     func testCompleteSessionFlow() {
         let engine = PracticeEngine()

--- a/ios/Tests/PracticeDomainTests/PracticeStorageTests.swift
+++ b/ios/Tests/PracticeDomainTests/PracticeStorageTests.swift
@@ -80,6 +80,28 @@ final class PracticeStorageTests: XCTestCase {
         XCTAssertEqual(loaded.first?.id, session.id)
     }
 
+    func testSessionRoundTripPersistsTempoFields() {
+        let block = PracticeBlock(
+            kind: .techniqueOrTheory,
+            title: "Tempo Block",
+            targetMinutes: 2,
+            actualMinutes: 1,
+            instructions: [],
+            startingBPM: 72,
+            endingBPM: 80,
+            tempoAdjustmentCount: 3
+        )
+        let session = PracticeSession(blocks: [block])
+
+        storage.saveSessions([session])
+        let loaded = storage.loadSessions().first!
+
+        let loadedBlock = loaded.blocks.first!
+        XCTAssertEqual(loadedBlock.startingBPM, 72)
+        XCTAssertEqual(loadedBlock.endingBPM, 80)
+        XCTAssertEqual(loadedBlock.tempoAdjustmentCount, 3)
+    }
+
     // MARK: - Items Round Trip Tests
 
     func testItemsRoundTripPreservesSRS() {
@@ -134,6 +156,37 @@ final class PracticeStorageTests: XCTestCase {
         XCTAssertNil(loaded.srs.lastPlayed)
     }
 
+    func testItemsRoundTripPersistsTempoState() {
+        let history = [
+            TempoSession(date: Date(timeIntervalSince1970: 1_000), startBPM: 70, endBPM: 75, adjustmentCount: 1, feedback: .good)
+        ]
+        let tempo = TempoState(
+            currentBPM: 80,
+            targetBPM: 120,
+            history: history,
+            lastPracticedBPM: 75,
+            progressionRate: 1.2
+        )
+        let item = PracticeItem(
+            catalogID: "test_tempo_round_trip",
+            category: .technique,
+            title: "Tempo Item",
+            tempo: tempo
+        )
+
+        storage.saveItems([item])
+        let loaded = storage.loadItems().first!
+
+        XCTAssertEqual(loaded.tempo.currentBPM, 80)
+        XCTAssertEqual(loaded.tempo.targetBPM, 120)
+        XCTAssertEqual(loaded.tempo.lastPracticedBPM, 75)
+        XCTAssertEqual(loaded.tempo.progressionRate, 1.2, accuracy: 0.001)
+        XCTAssertEqual(loaded.tempo.history.count, 1)
+        XCTAssertEqual(loaded.tempo.history.first?.startBPM, 70)
+        XCTAssertEqual(loaded.tempo.history.first?.endBPM, 75)
+        XCTAssertEqual(loaded.tempo.history.first?.feedback, .good)
+    }
+
     // MARK: - Catalog Merge Tests
 
     func testLoadPracticeItemsMergesSRSStateFromStorage() {
@@ -157,6 +210,35 @@ final class PracticeStorageTests: XCTestCase {
         XCTAssertEqual(mergedItem.category, firstCatalogItem.category)
         XCTAssertEqual(mergedItem.srs.stability, 5.0, accuracy: 0.001)
         XCTAssertNotNil(mergedItem.srs.lastPlayed)
+    }
+
+    func testLoadPracticeItemsMergesTempoStateFromStorage() {
+        let now = Date()
+        let catalogItems = PracticeItemCatalog.seedItems(now: now)
+        let firstCatalogItem = catalogItems.first!
+
+        var storedItem = firstCatalogItem
+        storedItem.tempo = TempoState(
+            currentBPM: 95,
+            targetBPM: 120,
+            history: [
+                TempoSession(date: now, startBPM: 90, endBPM: 95, adjustmentCount: 2, feedback: .good)
+            ],
+            lastPracticedBPM: 95,
+            progressionRate: 1.1
+        )
+
+        storage.saveItems([storedItem])
+
+        let mergedItems = storage.loadPracticeItems(now: now)
+        let mergedItem = mergedItems.first { $0.catalogID == firstCatalogItem.catalogID }!
+
+        XCTAssertEqual(mergedItem.tempo.currentBPM, 95)
+        XCTAssertEqual(mergedItem.tempo.lastPracticedBPM, 95)
+        XCTAssertEqual(mergedItem.tempo.history.count, 1)
+        XCTAssertEqual(mergedItem.tempo.history.first?.endBPM, 95)
+        XCTAssertEqual(mergedItem.tempo.progressionRate, 1.1, accuracy: 0.001)
+        XCTAssertEqual(mergedItem.targetMinutes, firstCatalogItem.targetMinutes)
     }
 
     func testLoadPracticeItemsPreservesCatalogItemsWithoutStoredState() {
@@ -296,6 +378,41 @@ final class PracticeStorageTests: XCTestCase {
         XCTAssertEqual(loadedItem.srs.stability, 2.5, accuracy: 0.001)
     }
 
+    func testLoadItemsFromSchemaV1AddsTempoDefaults() {
+        let now = Date()
+        let itemsURL = testDirectory.appendingPathComponent("items.json")
+        let formatter = ISO8601DateFormatter()
+
+        let legacyStore: [String: Any] = [
+            "schemaVersion": 1,
+            "items": [[
+                "id": UUID().uuidString,
+                "catalogID": "legacy_item",
+                "category": "warmup",
+                "title": "Legacy Item",
+                "detail": "",
+                "targetMinutes": 3,
+                "srs": [
+                    "stability": 1.0,
+                    "nextDue": formatter.string(from: now),
+                    "lastBonusTipIndex": -1,
+                    "lastFocusCueIndex": -1
+                ]
+            ]]
+        ]
+
+        let data = try! JSONSerialization.data(withJSONObject: legacyStore)
+        try! data.write(to: itemsURL)
+
+        let loaded = storage.loadItems()
+        XCTAssertEqual(loaded.count, 1)
+
+        let loadedItem = loaded.first!
+        XCTAssertEqual(loadedItem.catalogID, "legacy_item")
+        XCTAssertEqual(loadedItem.tempo.currentBPM, PracticeItemCategory.warmup.defaultBPM)
+        XCTAssertTrue(loadedItem.tempo.history.isEmpty)
+    }
+
     func testLoadSessionsFromFutureVersionReturnsEmpty() {
         // Create a session store with a future schema version
         let futureVersion = PracticeStorage.schemaVersion + 10
@@ -346,6 +463,39 @@ final class PracticeStorageTests: XCTestCase {
         // Should return empty for unknown future version
         let loaded = storage.loadItems()
         XCTAssertTrue(loaded.isEmpty)
+    }
+
+    func testLoadSessionsFromSchemaV1WithoutTempoFields() {
+        let sessionsURL = testDirectory.appendingPathComponent("sessions.json")
+        let formatter = ISO8601DateFormatter()
+
+        let legacyStore: [String: Any] = [
+            "schemaVersion": 1,
+            "sessions": [[
+                "id": UUID().uuidString,
+                "date": formatter.string(from: Date()),
+                "blocks": [[
+                    "id": UUID().uuidString,
+                    "kind": "warmup",
+                    "title": "Legacy Block",
+                    "detail": "",
+                    "targetMinutes": 3,
+                    "actualMinutes": 2
+                ]]
+            ]]
+        ]
+
+        let data = try! JSONSerialization.data(withJSONObject: legacyStore)
+        try! data.write(to: sessionsURL)
+
+        let loaded = storage.loadSessions()
+
+        XCTAssertEqual(loaded.count, 1)
+        let loadedBlock = loaded.first!.blocks.first!
+        XCTAssertNil(loadedBlock.startingBPM)
+        XCTAssertNil(loadedBlock.endingBPM)
+        XCTAssertEqual(loadedBlock.tempoAdjustmentCount, 0)
+        XCTAssertEqual(loadedBlock.actualMinutes, 2)
     }
 
     func testMigrationPreservesAllSessionData() {

--- a/ios/Tests/PracticeDomainTests/SpacedRepetitionEngineTests.swift
+++ b/ios/Tests/PracticeDomainTests/SpacedRepetitionEngineTests.swift
@@ -113,6 +113,41 @@ final class SpacedRepetitionEngineTests: XCTestCase {
         XCTAssertLessThanOrEqual(session.blocks.count, 8, "Should have at most 8 blocks")
     }
 
+    func testGenerateTodaySessionWhenNoItemsReturnsEmptySession() {
+        let engine = SpacedRepetitionEngine()
+
+        let session = engine.generateTodaySession()
+
+        XCTAssertTrue(session.blocks.isEmpty, "Should return an empty session when no items are available")
+    }
+
+    func testGenerateTodaySessionInterleavesMiddleWhenVarietyExists() {
+        let now = Date()
+        let warmup = PracticeItem(catalogID: "test_interleave_warm", category: .warmup, title: "Warmup", srs: SRSState(nextDue: now))
+        let technique = PracticeItem(catalogID: "test_interleave_tech", category: .technique, title: "Technique", srs: SRSState(nextDue: now))
+        let solo = PracticeItem(catalogID: "test_interleave_solo", category: .soloing, title: "Solo", srs: SRSState(nextDue: now))
+        let rhythm = PracticeItem(catalogID: "test_interleave_rhythm", category: .rhythm, title: "Rhythm", srs: SRSState(nextDue: now))
+        let fun = PracticeItem(catalogID: "test_interleave_fun", category: .repertoire, title: "Fun Ending", srs: SRSState(nextDue: now))
+
+        let engine = SpacedRepetitionEngine()
+        [warmup, technique, solo, rhythm, fun].forEach(engine.addItem)
+
+        let session = engine.generateTodaySession(
+            now: now,
+            targetMinutes: 20,
+            minBlocks: 4,
+            maxBlocks: 4
+        )
+
+        let kinds = session.blocks.map(\.kind)
+        XCTAssertEqual(kinds.first, .warmup)
+        XCTAssertEqual(kinds.last, .song)
+
+        let middleKinds = Array(kinds.dropFirst().dropLast())
+        XCTAssertEqual(middleKinds.count, 2)
+        XCTAssertNotEqual(middleKinds[0], middleKinds[1], "Middle blocks should interleave when different categories exist")
+    }
+
     // MARK: - Batch Feedback Tests
 
     func testApplyFeedbackUpdatesMultipleItems() {
@@ -592,6 +627,44 @@ final class SpacedRepetitionEngineTests: XCTestCase {
                 XCTAssertNil(block.startingBPM, "\(block.kind) block should NOT have startingBPM")
             }
         }
+    }
+
+    func testApplyFeedbackAndTempoLearningTogether() {
+        let now = Date(timeIntervalSince1970: 12_345)
+        let item = PracticeItem(
+            catalogID: "test_combo",
+            category: .technique,
+            title: "Combo Item",
+            srs: SRSState(stability: 1.5, nextDue: now),
+            tempo: TempoState(currentBPM: 70)
+        )
+
+        let engine = SpacedRepetitionEngine()
+        engine.addItem(item)
+
+        let blocks = [
+            PracticeBlock(
+                kind: .techniqueOrTheory,
+                title: "Block",
+                practiceItemID: item.id,
+                feedback: .good,
+                startingBPM: 70,
+                endingBPM: 75,
+                tempoAdjustmentCount: 2
+            )
+        ]
+
+        engine.applyFeedback(for: blocks, now: now)
+        engine.applyTempoLearning(for: blocks)
+
+        guard let updated = engine.item(withID: item.id) else {
+            return XCTFail("Item should still exist after updates")
+        }
+
+        XCTAssertNotNil(updated.srs.lastPlayed)
+        XCTAssertGreaterThan(updated.srs.stability, item.srs.stability)
+        XCTAssertEqual(updated.tempo.history.first?.adjustmentCount, 2)
+        XCTAssertGreaterThan(updated.tempo.currentBPM, item.tempo.currentBPM)
     }
     
     func testItemLookup() {


### PR DESCRIPTION
Closes #74

## Summary
- expand PracticeEngine coverage for preview->inBlock flows, pause guardrails, and empty/custom session edges
- tighten SRE tests for 6–8 block generation ordering/interleaving and feedback+tempo updates
- add storage v2 tests for tempo fields, catalog merge, and v1 migration defaults; update schema comments

## Testing
- swift test